### PR TITLE
Fix offset of relevantIndexes

### DIFF
--- a/src/RawParser.js
+++ b/src/RawParser.js
@@ -19,7 +19,7 @@ export default class RawParser {
     relevantIndexes = this.addIndexes(relevantIndexes, entityRanges);
     // add text start and end to relevant indexes
     relevantIndexes.push(0);
-    relevantIndexes.push(text.length - 1);
+    relevantIndexes.push(text.length);
     const uniqueRelevantIndexes = relevantIndexes.filter(
       (value, index, self) => self.indexOf(value) === index
     );


### PR DESCRIPTION
Fix the bug of blocks with content with length=1 

It seems that the relevantIndexes needs to be the index (not -1), otherwise the code which slices the range is always missing the index (returning -1), then slicing from the LHS - is this expected? (ive only slightly grokked the code, and the fix seems to work)