### PR TITLE
remove check if first block is empty

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -138,7 +138,7 @@ export const render = (raw, renderers = {}, arg3 = {}, arg4 = {}) => {
     deprecated('passing renderers separetly is deprecated'); // eslint-disable-line
   }
   const blocks = byDepth(raw.blocks);
-  if (!blocks || blocks[0].text.length === 0) {
+  if (!blocks) {
     return null;
   }
   return renderBlocks(blocks, inlineRendrers, blockRenderers, entityRenderers, raw.entityMap);


### PR DESCRIPTION
fixes #4 

Iam not sure why this check exactly is there, was it to check if there is any non-empty block?
Then maybe a scan function which checks all blocks is better