### PR TITLE
Fixes final ContentNode being unstyled when there are mutliple in a block

### DIFF
--- a/src/RawParser.js
+++ b/src/RawParser.js
@@ -30,7 +30,7 @@ function createEntityNodes(entityRanges, text) {
   if (lastIndex < text.length) {
     nodes.push(new ContentNode({
       start: lastIndex,
-      end: lastIndex + text.length,
+      end: text.length,
     }));
   }
   return nodes;


### PR DESCRIPTION
When there's an unstyled ContentNode at the end of a long string, the remaining bit (the extra ContentNode) is given an `end` position past the end of the string. This means `RawParser.relevantStyles` will match no styles (since none can exist past the end of the string), and it'll be incorrectly unstyled.

This only applies in blocks with multiple ContentNodes.