### PR TITLE
Expose block keys to block renderers

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -89,15 +89,17 @@ const renderBlocks = (blocks, inlineRendrers = {}, blockRenderers = {},
   const rendered = [];
   let group = [];
   let prevType = null;
-  const Parser = new RawParser();
   let prevDepth = 0;
+  let prevKey = null;
+  const Parser = new RawParser();
+
   blocks.forEach((block) => {
     const node = Parser.parse(block);
     const renderedNode = renderNode(node, inlineRendrers, entityRenderers, entityMap);
     // if type of the block has changed render the block and clear group
     if (prevType && prevType !== block.type) {
       if (blockRenderers[prevType]) {
-        rendered.push(blockRenderers[prevType](group, prevDepth));
+        rendered.push(blockRenderers[prevType](group, prevDepth, prevKey));
       } else {
         rendered.push(group);
       }
@@ -115,10 +117,11 @@ const renderBlocks = (blocks, inlineRendrers = {}, blockRenderers = {},
     // lastly save current type for refference
     prevType = block.type;
     prevDepth = block.depth;
+    prevKey = block.key;
   });
   // render last group
   if (blockRenderers[prevType]) {
-    rendered.push(blockRenderers[prevType](group, prevDepth));
+    rendered.push(blockRenderers[prevType](group, prevDepth, prevKey));
   } else {
     rendered.push(group);
   }

--- a/src/render.js
+++ b/src/render.js
@@ -18,7 +18,7 @@ const pushString = (string, array, index) => {
 /**
  * Recursively renders a node with nested nodes with given callbacks
  */
-export const renderNode = (node, styleRendrers, entityRenderers, entityMap) => {
+export const renderNode = (node, styleRenderers, entityRenderers, entityMap) => {
   let children = [];
   let index = 0;
   node.content.forEach((part) => {
@@ -26,12 +26,12 @@ export const renderNode = (node, styleRendrers, entityRenderers, entityMap) => {
       children = pushString(part, children, index);
     } else {
       index += 1;
-      children[index] = renderNode(part, styleRendrers, entityRenderers, entityMap);
+      children[index] = renderNode(part, styleRenderers, entityRenderers, entityMap);
       index += 1;
     }
   });
-  if (node.style && styleRendrers[node.style]) {
-    return styleRendrers[node.style](children);
+  if (node.style && styleRenderers[node.style]) {
+    return styleRenderers[node.style](children);
   }
   if (node.entity !== null) {
     const entity = entityMap[node.entity];

--- a/src/render.js
+++ b/src/render.js
@@ -83,7 +83,7 @@ const byDepth = (blocks) => {
 /**
  * Renders blocks grouped by type using provided blockStyleRenderers
  */
-const renderBlocks = (blocks, inlineRendrers = {}, blockRenderers = {},
+const renderBlocks = (blocks, inlineRenderers = {}, blockRenderers = {},
                       entityRenderers = {}, entityMap = {}) => {
   // initialize
   const rendered = [];
@@ -95,7 +95,7 @@ const renderBlocks = (blocks, inlineRendrers = {}, blockRenderers = {},
 
   blocks.forEach((block) => {
     const node = Parser.parse(block);
-    const renderedNode = renderNode(node, inlineRendrers, entityRenderers, entityMap);
+    const renderedNode = renderNode(node, inlineRenderers, entityRenderers, entityMap);
     // if type of the block has changed render the block and clear group
     if (prevType && prevType !== block.type) {
       if (blockRenderers[prevType]) {
@@ -107,7 +107,7 @@ const renderBlocks = (blocks, inlineRendrers = {}, blockRenderers = {},
     }
     // handle children
     if (block.children) {
-      const children = renderBlocks(block.children, inlineRendrers,
+      const children = renderBlocks(block.children, inlineRenderers,
       blockRenderers, entityRenderers, entityMap);
       renderedNode.push(children);
     }
@@ -140,17 +140,17 @@ export const render = (raw, renderers = {}, arg3 = {}, arg4 = {}) => {
   if (!raw.blocks.length) {
     return null;
   }
-  let { inline: inlineRendrers, blocks: blockRenderers, entities: entityRenderers } = renderers;
+  let { inline: inlineRenderers, blocks: blockRenderers, entities: entityRenderers } = renderers;
   // Fallback to deprecated api
-  if (!inlineRendrers && !blockRenderers && !entityRenderers) {
-    inlineRendrers = renderers;
+  if (!inlineRenderers && !blockRenderers && !entityRenderers) {
+    inlineRenderers = renderers;
     blockRenderers = arg3;
     entityRenderers = arg4;
     // Logs a deprecation warning if not in production
     deprecated('passing renderers separetly is deprecated'); // eslint-disable-line
   }
   const blocks = byDepth(raw.blocks);
-  return renderBlocks(blocks, inlineRendrers, blockRenderers, entityRenderers, raw.entityMap);
+  return renderBlocks(blocks, inlineRenderers, blockRenderers, entityRenderers, raw.entityMap);
 };
 
 export const renderRaw = (...args) => {

--- a/src/render.js
+++ b/src/render.js
@@ -90,7 +90,7 @@ const renderBlocks = (blocks, inlineRenderers = {}, blockRenderers = {},
   let group = [];
   let prevType = null;
   let prevDepth = 0;
-  let prevKey = null;
+  let prevKeys = [];
   const Parser = new RawParser();
 
   blocks.forEach((block) => {
@@ -99,7 +99,8 @@ const renderBlocks = (blocks, inlineRenderers = {}, blockRenderers = {},
     // if type of the block has changed render the block and clear group
     if (prevType && prevType !== block.type) {
       if (blockRenderers[prevType]) {
-        rendered.push(blockRenderers[prevType](group, prevDepth, prevKey));
+        rendered.push(blockRenderers[prevType](group, prevDepth, prevKeys));
+        prevKeys = [];
       } else {
         rendered.push(group);
       }
@@ -117,11 +118,11 @@ const renderBlocks = (blocks, inlineRenderers = {}, blockRenderers = {},
     // lastly save current type for refference
     prevType = block.type;
     prevDepth = block.depth;
-    prevKey = block.key;
+    prevKeys.push(block.key);
   });
   // render last group
   if (blockRenderers[prevType]) {
-    rendered.push(blockRenderers[prevType](group, prevDepth, prevKey));
+    rendered.push(blockRenderers[prevType](group, prevDepth, prevKeys));
   } else {
     rendered.push(group);
   }

--- a/test/render.js
+++ b/test/render.js
@@ -374,10 +374,10 @@ const renderers = {
 };
 
 const blocksWithKeys = {
-  unstyled: (children, depth, key) => `<p key="${key}">${joinRecursively(children)}</p>`,
-  blockquote: (children, depth, key) => `<blockquote key="${key}">${joinRecursively(children)}</blockquote>`,
-  'ordered-list-item': (children, depth, key) => `<ol key="${key}">${makeList(children)}</ol>`,
-  'unordered-list-item': (children, depth, key) => `<ul key="${key}">${makeList(children)}</ul>`,
+  unstyled: (children, depth, keys) => `<p key="${keys.join(',')}">${joinRecursively(children)}</p>`,
+  blockquote: (children, depth, keys) => `<blockquote key="${keys.join(',')}">${joinRecursively(children)}</blockquote>`,
+  'ordered-list-item': (children, depth, keys) => `<ol key="${keys.join(',')}">${makeList(children)}</ol>`,
+  'unordered-list-item': (children, depth, keys) => `<ul key="${keys.join(',')}">${makeList(children)}</ul>`,
 };
 
 const renderersWithKeys = {
@@ -435,7 +435,7 @@ describe('renderRaw', () => {
   it('should render blocks with the block keys', () => {
     const rendered = redraft(raw3, renderersWithKeys);
     const joined = joinRecursively(rendered);
-    joined.should.equal('<p key="e047l">Paragraph one</p><blockquote key="c3taj">A quoteSpanning multiple lines</blockquote><p key="6aaeh">A second paragraph.</p>'); // eslint-disable-line max-len
+    joined.should.equal('<p key="e047l">Paragraph one</p><blockquote key="520kr,c3taj">A quoteSpanning multiple lines</blockquote><p key="6aaeh">A second paragraph.</p>'); // eslint-disable-line max-len
   });
   it('should render null for empty raw blocks array', () => {
     const rendered = redraft(emptyRaw, renderers);

--- a/test/render.js
+++ b/test/render.js
@@ -78,6 +78,43 @@ const raw2 = {
   }],
 };
 
+const raw3 = {
+  entityMap: {},
+  blocks: [{
+    key: 'e047l',
+    text: 'Paragraph one',
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+    data: {},
+  }, {
+    key: '520kr',
+    text: 'A quote',
+    type: 'blockquote',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+    data: {},
+  }, {
+    key: 'c3taj',
+    text: 'Spanning multiple lines',
+    type: 'blockquote',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+    data: {},
+  }, {
+    key: '6aaeh',
+    text: 'A second paragraph.',
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+    data: {},
+  }],
+};
+
 const rawWithEmptyLine = {
   entityMap: {},
   blocks: [{
@@ -336,6 +373,19 @@ const renderers = {
   entities,
 };
 
+const blocksWithKeys = {
+  unstyled: (children, depth, key) => `<p key="${key}">${joinRecursively(children)}</p>`,
+  blockquote: (children, depth, key) => `<blockquote key="${key}">${joinRecursively(children)}</blockquote>`,
+  'ordered-list-item': (children, depth, key) => `<ol key="${key}">${makeList(children)}</ol>`,
+  'unordered-list-item': (children, depth, key) => `<ul key="${key}">${makeList(children)}</ul>`,
+};
+
+const renderersWithKeys = {
+  inline,
+  blocks: blocksWithKeys,
+  entities,
+};
+
 describe('renderRaw', () => {
   it('should render correctly', () => {
     const rendered = redraft(raw, renderers);
@@ -381,6 +431,11 @@ describe('renderRaw', () => {
     const rendered = redraft(rawStyleWithEntities, renderers);
     const joined = joinRecursively(rendered);
     joined.should.equal('<p><strong>This </strong><div style="color: #ee6a56" ><strong>is a </strong></div><div style="color: #ee6a56" ><strong>Greeting</strong></div><div style="color: #ee6a56" ><strong> redraft</strong></div><strong>bug.</strong></p>'); // eslint-disable-line max-len
+  });
+  it('should render blocks with the block keys', () => {
+    const rendered = redraft(raw3, renderersWithKeys);
+    const joined = joinRecursively(rendered);
+    joined.should.equal('<p key="e047l">Paragraph one</p><blockquote key="c3taj">A quoteSpanning multiple lines</blockquote><p key="6aaeh">A second paragraph.</p>'); // eslint-disable-line max-len
   });
   it('should render null for empty raw blocks array', () => {
     const rendered = redraft(emptyRaw, renderers);


### PR DESCRIPTION
This pull request exposes the block key to the block renderer function. The use case is rendering a changing draft-js ContentState to React elements with consistent keys throughout re-renders.