### PR TITLE
Add cleanup functionality

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["latest"],
+  "plugins": ["array-includes"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
     "mocha": true
   },
   "rules": {
-      "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
+      "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+      "react/require-extension": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch": "rimraf lib && babel src --out-dir lib --watch",
     "lint": "eslint src",
     "prepublish": "npm run compile && npm test",
-    "mocha": "mocha --compilers js:babel-core/register",
+    "mocha": "mocha --compilers js:babel-register",
     "test": "npm run lint && npm run mocha"
   },
   "repository": {
@@ -26,7 +26,9 @@
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.2",
     "babel-eslint": "^7.0.0",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-plugin-array-includes": "^2.0.3",
+    "babel-preset-latest": "^6.16.0",
+    "babel-register": "^6.16.3",
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "eslint-config-airbnb": "^11.2.0",

--- a/src/checkClenup.js
+++ b/src/checkClenup.js
@@ -29,7 +29,7 @@ const checkCleanup = (block, prevType, { cleanup }) => {
     return false;
   }
   // Check if cleanup is enabled after prev type
-  if (cleanup.after !== 'all' && !cleanup.after.includes(prevType)) {
+  if (cleanup.after && (cleanup.after !== 'all' && !cleanup.after.includes(prevType))) {
     return false;
   }
   // Handle the except array if passed

--- a/src/checkClenup.js
+++ b/src/checkClenup.js
@@ -1,0 +1,46 @@
+/**
+ * Check if block has any text, respects trim setting
+ */
+const hasText = (text, { trim }) => !!(trim ? text.trim() : text);
+
+
+/**
+ * Check if block has any data like text, metadata or entities
+ */
+const hasData = (block, options) => {
+  if (hasText(block.text, options)) {
+    return true;
+  }
+  if (block.data && Object.keys(block.data).length) {
+    return true;
+  }
+  if (block.entityRanges && block.entityRanges.length) {
+    return true;
+  }
+  return false;
+};
+
+
+/**
+ * Checks if current block is empty and if it should be ommited according to passed settings
+ */
+const checkCleanup = (block, prevType, { cleanup }) => {
+  if (!cleanup || hasData(block, cleanup)) {
+    return false;
+  }
+  // Check if cleanup is enabled after prev type
+  if (cleanup.after !== 'all' && !cleanup.after.includes(prevType)) {
+    return false;
+  }
+  // Handle the except array if passed
+  if (cleanup.except && !cleanup.except.includes(block.type)) {
+    return true;
+  }
+  // Finaly if cleanup is enabled for current type
+  if (cleanup.types && (cleanup.types === 'all' || cleanup.types.includes(block.type))) {
+    return true;
+  }
+  return false;
+};
+
+export default checkCleanup;

--- a/src/render.js
+++ b/src/render.js
@@ -137,11 +137,11 @@ const renderBlocks = (blocks, inlineRenderers = {}, blockRenderers = {},
   const Parser = new RawParser();
 
   blocks.forEach((block) => {
-    const node = Parser.parse(block);
-    const renderedNode = renderNode(node, inlineRenderers, entityRenderers, entityMap, options);
     if (checkCleanup(block, prevType, options)) {
       return;
     }
+    const node = Parser.parse(block);
+    const renderedNode = renderNode(node, inlineRenderers, entityRenderers, entityMap, options);
     // if type of the block has changed render the block and clear group
     if (prevType && prevType !== block.type) {
       if (blockRenderers[prevType]) {

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,6 @@
 import RawParser from './RawParser';
 import warn from './warn';
+import checkCleanup from './checkClenup';
 
 const defaultOptions = {
   joinOutput: false,
@@ -31,29 +32,6 @@ const checkJoin = (input, options) => {
     return input.join('');
   }
   return input;
-};
-
-/**
- * Check if text is false with or without trim depending on cleanup settings
- */
-const hasText = (text, { trim }) => !!(trim ? text.trim() : text);
-
-/**
- * Checks if current block is empty and if it should be ommited according to passed settings
- */
-const checkCleanup = (block, prevType, { cleanup }) => {
-  if (!cleanup || hasText(block.text, cleanup)) {
-    return false;
-  }
-  // Check if cleanup is enabled after prev type
-  if (cleanup.after !== 'all' && !cleanup.after.includes(prevType)) {
-    return false;
-  }
-  // Finaly if cleanup is enabled for current type
-  if (cleanup.types === 'all' || cleanup.types.includes(block.type)) {
-    return true;
-  }
-  return false;
 };
 
 /**

--- a/test/cleanup.js
+++ b/test/cleanup.js
@@ -1,0 +1,102 @@
+import chai from 'chai';
+import redraft from '../src';
+import * as raws from './raws';
+import { joinRecursively, makeList } from './helpers';
+
+chai.should();
+
+
+// render to HTML
+const inline = {
+  BOLD: (children) => `<strong>${children.join('')}</strong>`,
+  ITALIC: (children) => `<em>${children.join('')}</em>`,
+  UND: (children) => `<em>${children.join('')}</em>`,
+};
+
+const atomicBlocks = {
+  resizable: (children, { width }, key) => `<div key="${key}" style="width: ${width};" >${joinRecursively(children)}</div>`,
+  image: (children, { src, alt }, key) => `<img key="${key}" src="${src}" alt="${alt}" />`,
+};
+
+const blocks = {
+  unstyled: (children) => `<p>${joinRecursively(children)}</p>`,
+  blockquote: (children) => `<blockquote>${joinRecursively(children)}</blockquote>`,
+  atomic: (children, _, { keys, data }) => {
+    const maped = children.map(
+      (child, i) => atomicBlocks[data[i].type](child, data[i], keys[i])
+    );
+    return joinRecursively(maped);
+  },
+};
+
+const entities = {
+  LINK: (children, entity) => `<a href="${entity.url}" >${joinRecursively(children)}</a>`,
+  ENTITY: (children, entity) => `<div style="color: ${entity.data.color}" >${joinRecursively(children)}</div>`,
+};
+
+
+// render to HTML
+
+
+const renderers = {
+  inline,
+  blocks,
+  entities,
+};
+
+describe('redraft with cleanup', () => {
+  it('should skip only empty unstyled blocks after atomic', () => {
+    const rendered = redraft(raws.rawWithEmptyBlocks, renderers);
+    const joined = joinRecursively(rendered);
+    joined.should.equal('<div key="1" style="width: 300px;" >A</div><div key="2" style="width: 100px;" >B</div><blockquote></blockquote><img key="3" src="img.png" alt="D" /><p> </p>'); // eslint-disable-line max-len
+  });
+  it('should respect trim option', () => {
+    const rendered = redraft(raws.rawWithEmptyBlocks, renderers, {
+      cleanup: { types: ['unstyled'], after: ['atomic'], trim: true },
+    });
+    const joined = joinRecursively(rendered);
+    joined.should.equal('<div key="1" style="width: 300px;" >A</div><div key="2" style="width: 100px;" >B</div><blockquote></blockquote><img key="3" src="img.png" alt="D" />'); // eslint-disable-line max-len
+  });
+  it('should respect passing types as an array', () => {
+    const rendered = redraft(raws.rawWithEmptyBlocks, renderers, {
+      cleanup: { types: ['unstyled', 'blockquote'], after: ['atomic'], trim: false },
+    });
+    const joined = joinRecursively(rendered);
+    joined.should.equal('<div key="1" style="width: 300px;" >A</div><div key="2" style="width: 100px;" >B</div><img key="3" src="img.png" alt="D" /><p> </p>'); // eslint-disable-line max-len
+  });
+  it('should respect passing \'all\' to types', () => {
+    const rendered = redraft(raws.rawWithEmptyBlocks, renderers, {
+      cleanup: { types: 'all', after: ['atomic'], trim: false },
+    });
+    const joined = joinRecursively(rendered);
+    joined.should.equal('<div key="1" style="width: 300px;" >A</div><div key="2" style="width: 100px;" >B</div><img key="3" src="img.png" alt="D" /><p> </p>'); // eslint-disable-line max-len
+  });
+  it('should check for data when triming', () => {
+    const rendered = redraft(raws.rawWithEmptyBlocks2, renderers, {
+      cleanup: { types: 'all', after: ['unstyled', 'atomic', 'blockquote'], trim: true },
+    });
+    const joined = joinRecursively(rendered);
+    joined.should.equal('<p></p><div key="a1" style="width: 300px;" ></div><p>A</p><div key="a2" style="width: 300px;" > </div>'); // eslint-disable-line max-len
+  });
+  it('should respect passing \'all\' to after', () => {
+    const rendered = redraft(raws.rawWithEmptyBlocks2, renderers, {
+      cleanup: { types: 'all', after: 'all', trim: false },
+    });
+    const joined = joinRecursively(rendered);
+    joined.should.equal('<div key="a1" style="width: 300px;" ></div><p>A</p><div key="a2" style="width: 300px;" > </div>'); // eslint-disable-line max-len
+  });
+  it('should respect passing except array', () => {
+    const rendered = redraft(raws.rawWithEmptyBlocks2, renderers, {
+      cleanup: { except: ['blockquote'], after: 'all', trim: false },
+    });
+    const joined = joinRecursively(rendered);
+    joined.should.equal('<div key="a1" style="width: 300px;" ></div><p>A</p><blockquote></blockquote><div key="a2" style="width: 300px;" > </div>'); // eslint-disable-line max-len
+  });
+  it('should render all blocks with cleanup disabled', () => {
+    const rendered = redraft(raws.rawWithEmptyBlocks, renderers, {
+      cleanup: false,
+    });
+    const joined = joinRecursively(rendered);
+    joined.should.equal('<div key="1" style="width: 300px;" >A</div><p></p><div key="2" style="width: 100px;" >B</div><blockquote></blockquote><img key="3" src="img.png" alt="D" /><p> </p>'); // eslint-disable-line max-len
+  });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,9 @@
+// to render to a plain string we need to be sure all the arrays are joined after render
+export const joinRecursively = (array) => array.map((child) => {
+  if (Array.isArray(child)) {
+    return joinRecursively(child);
+  }
+  return child;
+}).join('');
+
+export const makeList = children => children.map(child => `<li>${joinRecursively(child)}</li>`).join('');

--- a/test/raws.js
+++ b/test/raws.js
@@ -1,0 +1,485 @@
+export const raw = {
+  entityMap: {
+    0: {
+      data: {
+        url: 'http://zombo.com/',
+      },
+      type: 'LINK',
+      mutability: 'MUTABLE',
+    },
+  },
+  blocks: [{
+    key: '77n1t',
+    text: 'Lorem ipsum dolor sit amet, pro nisl sonet ad. ',
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [
+      {
+        offset: 0,
+        length: 17,
+        style: 'BOLD',
+      },
+      {
+        offset: 6,
+        length: 21,
+        style: 'ITALIC',
+      },
+    ],
+    entityRanges: [
+      {
+        key: 0,
+        offset: 6,
+        length: 5,
+      },
+    ],
+  }, {
+    key: 'a005',
+    text: 'Eos affert numquam id, in est meis nobis. Legimus singulis suscipiantur eum in, ceteros invenire tractatos his id. ', // eslint-disable-line max-len
+    type: 'blockquote',
+    depth: 0,
+    inlineStyleRanges: [
+      {
+        offset: 80,
+        length: 17,
+        style: 'ITALIC',
+      },
+    ],
+    entityRanges: [],
+  }, {
+    key: 'ee96q',
+    text: 'Facer facilis definiebas ea pro, mei malis libris latine an. Senserit moderatius vituperata vis in.', // eslint-disable-line max-len
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [
+      {
+        offset: 0,
+        length: 99,
+        style: 'BOLD',
+      },
+    ],
+    entityRanges: [],
+  }],
+};
+
+export const raw2 = {
+  entityMap: {},
+  blocks: [{
+    key: 'az45a',
+    text: '!', // eslint-disable-line max-len
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+  }],
+};
+
+export const raw3 = {
+  entityMap: {},
+  blocks: [{
+    key: 'e047l',
+    text: 'Paragraph one',
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+    data: {},
+  }, {
+    key: '520kr',
+    text: 'A quote',
+    type: 'blockquote',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+    data: {},
+  }, {
+    key: 'c3taj',
+    text: 'Spanning multiple lines',
+    type: 'blockquote',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+    data: {},
+  }, {
+    key: '6aaeh',
+    text: 'A second paragraph.',
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+    data: {},
+  }],
+};
+
+export const rawWithEmptyLine = {
+  entityMap: {},
+  blocks: [{
+    key: 'az45a',
+    text: '!', // eslint-disable-line max-len
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+  }, {
+    key: 'az45b',
+    text: '', // eslint-disable-line max-len
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+  }, {
+    key: 'az45c',
+    text: '!', // eslint-disable-line max-len
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+  }],
+};
+
+export const rawEmptyFirstLine = {
+  entityMap: {},
+  blocks: [{
+    key: 'az45b',
+    text: '', // eslint-disable-line max-len
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+  }, {
+    key: 'az45a',
+    text: '!', // eslint-disable-line max-len
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+  }],
+};
+
+export const rawWithDepth = {
+  entityMap: {},
+  blocks: [
+    {
+      key: 'eunbc',
+      type: 'unordered-list-item',
+      text: 'Hey',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '9nl08',
+      type: 'unordered-list-item',
+      text: 'Ho',
+      depth: 1,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '9qp7i',
+      type: 'unordered-list-item',
+      text: 'Let\'s',
+      depth: 2,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '1hegu',
+      type: 'ordered-list-item',
+      text: 'Go',
+      depth: 2,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    }],
+};
+
+export const rawWithDepth2 = {
+  entityMap: {},
+  blocks: [
+    {
+      key: 'eunbc',
+      type: 'unordered-list-item',
+      text: 'Hey',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '9nl08',
+      type: 'unordered-list-item',
+      text: 'Ho',
+      depth: 1,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '9qp7i',
+      type: 'unordered-list-item',
+      text: 'Let\'s',
+      depth: 2,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '1hegu',
+      type: 'ordered-list-item',
+      text: 'Go',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    }],
+};
+
+export const emptyRaw = {
+  entityMap: {},
+  blocks: [],
+};
+
+export const invalidRaw = {
+  entityMap: {},
+  blocks: {},
+};
+
+export const rawWithDepth3 = {
+  entityMap: {},
+  blocks: [
+    {
+      key: 'eunbc',
+      type: 'unordered-list-item',
+      text: 'Hey',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '9nl08',
+      type: 'unordered-list-item',
+      text: 'Ho',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '9qp7i',
+      type: 'unordered-list-item',
+      text: 'Let\'s',
+      depth: 2,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '1hegu',
+      type: 'ordered-list-item',
+      text: 'Go',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    }],
+};
+
+export const rawStyleWithEntities = {
+  entityMap: {
+    0: {
+      type: 'ENTITY',
+      mutability: 'MUTABLE',
+      data: {
+        data: {
+          color: '#ee6a56',
+        },
+      },
+    },
+    1: {
+      type: 'ENTITY',
+      mutability: 'IMMUTABLE',
+      data: {
+        data: {
+          placeholder: 'greeting',
+          color: '#ee6a56',
+        },
+      },
+    },
+  },
+  blocks: [
+    {
+      key: 'qaie',
+      text: 'This is a Greeting redraftbug.',
+      type: 'unstyled',
+      depth: 0,
+      inlineStyleRanges: [
+        {
+          offset: 0,
+          length: 30,
+          style: 'BOLD',
+        },
+      ],
+      entityRanges: [
+        {
+          offset: 5,
+          length: 5,
+          key: 0,
+        }, {
+          offset: 10,
+          length: 8,
+          key: 1,
+        }, {
+          offset: 18,
+          length: 8,
+          key: 0,
+        },
+      ],
+      data: {},
+    },
+  ],
+};
+
+export const rawWithMetadata = {
+  entityMap: {},
+  blocks: [
+    {
+      key: '1',
+      type: 'atomic',
+      data: {
+        type: 'resizable',
+        width: '300px',
+      },
+      text: 'A',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '2',
+      type: 'atomic',
+      data: {
+        type: 'image',
+        src: 'img.png',
+        alt: 'C',
+      },
+      text: 'B',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    }],
+};
+
+export const rawWithEmptyBlocks = {
+  entityMap: {},
+  blocks: [
+    {
+      key: '1',
+      type: 'atomic',
+      data: {
+        type: 'resizable',
+        width: '300px',
+      },
+      text: 'A',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: 'u1',
+      type: 'unstyled',
+      text: '',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '2',
+      type: 'atomic',
+      data: {
+        type: 'resizable',
+        width: '100px',
+      },
+      text: 'B',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: 'u2',
+      type: 'blockquote',
+      text: '',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: '3',
+      type: 'atomic',
+      data: {
+        type: 'image',
+        src: 'img.png',
+        alt: 'D',
+      },
+      text: 'C',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: 'u3',
+      type: 'unstyled',
+      text: ' ',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+  ],
+};
+
+export const rawWithEmptyBlocks2 = {
+  entityMap: {},
+  blocks: [
+    {
+      key: 'u1',
+      type: 'unstyled',
+      text: '',
+      depth: 0,
+      data: {},
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: 'a1',
+      type: 'atomic',
+      data: {
+        type: 'resizable',
+        width: '300px',
+      },
+      text: '',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: 'u2',
+      type: 'unstyled',
+      text: 'A',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: 'b1',
+      type: 'blockquote',
+      text: '',
+      depth: 0,
+      data: {},
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+    {
+      key: 'a2',
+      type: 'atomic',
+      text: ' ',
+      depth: 0,
+      data: {
+        type: 'resizable',
+        width: '300px',
+      },
+      inlineStyleRanges: [],
+      entityRanges: [],
+    },
+  ],
+};

--- a/test/render.js
+++ b/test/render.js
@@ -1,431 +1,12 @@
 import chai from 'chai';
 import redraft from '../src';
+import * as raws from './raws';
+import { joinRecursively, makeList } from './helpers';
 
 const should = chai.should();
 
-const raw = {
-  entityMap: {
-    0: {
-      data: {
-        url: 'http://zombo.com/',
-      },
-      type: 'LINK',
-      mutability: 'MUTABLE',
-    },
-  },
-  blocks: [{
-    key: '77n1t',
-    text: 'Lorem ipsum dolor sit amet, pro nisl sonet ad. ',
-    type: 'unstyled',
-    depth: 0,
-    inlineStyleRanges: [
-      {
-        offset: 0,
-        length: 17,
-        style: 'BOLD',
-      },
-      {
-        offset: 6,
-        length: 21,
-        style: 'ITALIC',
-      },
-    ],
-    entityRanges: [
-      {
-        key: 0,
-        offset: 6,
-        length: 5,
-      },
-    ],
-  }, {
-    key: 'a005',
-    text: 'Eos affert numquam id, in est meis nobis. Legimus singulis suscipiantur eum in, ceteros invenire tractatos his id. ', // eslint-disable-line max-len
-    type: 'blockquote',
-    depth: 0,
-    inlineStyleRanges: [
-      {
-        offset: 80,
-        length: 17,
-        style: 'ITALIC',
-      },
-    ],
-    entityRanges: [],
-  }, {
-    key: 'ee96q',
-    text: 'Facer facilis definiebas ea pro, mei malis libris latine an. Senserit moderatius vituperata vis in.', // eslint-disable-line max-len
-    type: 'unstyled',
-    depth: 0,
-    inlineStyleRanges: [
-      {
-        offset: 0,
-        length: 99,
-        style: 'BOLD',
-      },
-    ],
-    entityRanges: [],
-  }],
-};
-
-const raw2 = {
-  entityMap: {},
-  blocks: [{
-    key: 'az45a',
-    text: '!', // eslint-disable-line max-len
-    type: 'unstyled',
-    depth: 0,
-    inlineStyleRanges: [],
-    entityRanges: [],
-  }],
-};
-
-const raw3 = {
-  entityMap: {},
-  blocks: [{
-    key: 'e047l',
-    text: 'Paragraph one',
-    type: 'unstyled',
-    depth: 0,
-    inlineStyleRanges: [],
-    entityRanges: [],
-    data: {},
-  }, {
-    key: '520kr',
-    text: 'A quote',
-    type: 'blockquote',
-    depth: 0,
-    inlineStyleRanges: [],
-    entityRanges: [],
-    data: {},
-  }, {
-    key: 'c3taj',
-    text: 'Spanning multiple lines',
-    type: 'blockquote',
-    depth: 0,
-    inlineStyleRanges: [],
-    entityRanges: [],
-    data: {},
-  }, {
-    key: '6aaeh',
-    text: 'A second paragraph.',
-    type: 'unstyled',
-    depth: 0,
-    inlineStyleRanges: [],
-    entityRanges: [],
-    data: {},
-  }],
-};
-
-const rawWithEmptyLine = {
-  entityMap: {},
-  blocks: [{
-    key: 'az45a',
-    text: '!', // eslint-disable-line max-len
-    type: 'unstyled',
-    depth: 0,
-    inlineStyleRanges: [],
-    entityRanges: [],
-  }, {
-    key: 'az45b',
-    text: '', // eslint-disable-line max-len
-    type: 'unstyled',
-    depth: 0,
-    inlineStyleRanges: [],
-    entityRanges: [],
-  }, {
-    key: 'az45c',
-    text: '!', // eslint-disable-line max-len
-    type: 'unstyled',
-    depth: 0,
-    inlineStyleRanges: [],
-    entityRanges: [],
-  }],
-};
-
-const rawEmptyFirstLine = {
-  entityMap: {},
-  blocks: [{
-    key: 'az45b',
-    text: '', // eslint-disable-line max-len
-    type: 'unstyled',
-    depth: 0,
-    inlineStyleRanges: [],
-    entityRanges: [],
-  }, {
-    key: 'az45a',
-    text: '!', // eslint-disable-line max-len
-    type: 'unstyled',
-    depth: 0,
-    inlineStyleRanges: [],
-    entityRanges: [],
-  }],
-};
-
-const rawWithDepth = {
-  entityMap: {},
-  blocks: [
-    {
-      key: 'eunbc',
-      type: 'unordered-list-item',
-      text: 'Hey',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: '9nl08',
-      type: 'unordered-list-item',
-      text: 'Ho',
-      depth: 1,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: '9qp7i',
-      type: 'unordered-list-item',
-      text: 'Let\'s',
-      depth: 2,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: '1hegu',
-      type: 'ordered-list-item',
-      text: 'Go',
-      depth: 2,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    }],
-};
-
-const rawWithDepth2 = {
-  entityMap: {},
-  blocks: [
-    {
-      key: 'eunbc',
-      type: 'unordered-list-item',
-      text: 'Hey',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: '9nl08',
-      type: 'unordered-list-item',
-      text: 'Ho',
-      depth: 1,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: '9qp7i',
-      type: 'unordered-list-item',
-      text: 'Let\'s',
-      depth: 2,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: '1hegu',
-      type: 'ordered-list-item',
-      text: 'Go',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    }],
-};
-
-const emptyRaw = {
-  entityMap: {},
-  blocks: [],
-};
-
-const invalidRaw = {
-  entityMap: {},
-  blocks: {},
-};
-
-const rawWithDepth3 = {
-  entityMap: {},
-  blocks: [
-    {
-      key: 'eunbc',
-      type: 'unordered-list-item',
-      text: 'Hey',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: '9nl08',
-      type: 'unordered-list-item',
-      text: 'Ho',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: '9qp7i',
-      type: 'unordered-list-item',
-      text: 'Let\'s',
-      depth: 2,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: '1hegu',
-      type: 'ordered-list-item',
-      text: 'Go',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    }],
-};
-
-const rawStyleWithEntities = {
-  entityMap: {
-    0: {
-      type: 'ENTITY',
-      mutability: 'MUTABLE',
-      data: {
-        data: {
-          color: '#ee6a56',
-        },
-      },
-    },
-    1: {
-      type: 'ENTITY',
-      mutability: 'IMMUTABLE',
-      data: {
-        data: {
-          placeholder: 'greeting',
-          color: '#ee6a56',
-        },
-      },
-    },
-  },
-  blocks: [
-    {
-      key: 'qaie',
-      text: 'This is a Greeting redraftbug.',
-      type: 'unstyled',
-      depth: 0,
-      inlineStyleRanges: [
-        {
-          offset: 0,
-          length: 30,
-          style: 'BOLD',
-        },
-      ],
-      entityRanges: [
-        {
-          offset: 5,
-          length: 5,
-          key: 0,
-        }, {
-          offset: 10,
-          length: 8,
-          key: 1,
-        }, {
-          offset: 18,
-          length: 8,
-          key: 0,
-        },
-      ],
-      data: {},
-    },
-  ],
-};
-
-const rawWithMetadata = {
-  entityMap: {},
-  blocks: [
-    {
-      key: '1',
-      type: 'atomic',
-      data: {
-        type: 'resizable',
-        width: '300px',
-      },
-      text: 'A',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: '2',
-      type: 'atomic',
-      data: {
-        type: 'image',
-        src: 'img.png',
-        alt: 'C',
-      },
-      text: 'B',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    }],
-};
-
-const rawWithEmptyBlocks = {
-  entityMap: {},
-  blocks: [
-    {
-      key: '1',
-      type: 'atomic',
-      data: {
-        type: 'resizable',
-        width: '300px',
-      },
-      text: 'A',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: 'u1',
-      type: 'unstyled',
-      text: '',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: '2',
-      type: 'atomic',
-      data: {
-        type: 'image',
-        src: 'img.png',
-        alt: 'C',
-      },
-      text: 'B',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-    {
-      key: 'u2',
-      type: 'unstyled',
-      text: ' ',
-      depth: 0,
-      inlineStyleRanges: [],
-      entityRanges: [],
-    },
-  ],
-};
-
-
-// to render to a plain string we need to be sure all the arrays are joined after render
-const joinRecursively = (array) => array.map((child) => {
-  if (Array.isArray(child)) {
-    return joinRecursively(child);
-  }
-  return child;
-}).join('');
-
-const makeList = children => children.map(child => `<li>${joinRecursively(child)}</li>`).join('');
 
 // render to HTML
-
 const inline = {
   BOLD: (children) => `<strong>${children.join('')}</strong>`,
   ITALIC: (children) => `<em>${children.join('')}</em>`,
@@ -509,84 +90,65 @@ const renderersWithData = {
 
 describe('redraft', () => {
   it('should render correctly', () => {
-    const rendered = redraft(raw, renderers);
+    const rendered = redraft(raws.raw, renderers);
     const joined = joinRecursively(rendered);
     joined.should.equal('<p><strong>Lorem </strong><a href="http://zombo.com/" ><strong><em>ipsum</em></strong></a><strong><em> dolor</em></strong><em> sit amet,</em> pro nisl sonet ad. </p><blockquote>Eos affert numquam id, in est meis nobis. Legimus singulis suscipiantur eum in, <em>ceteros invenire </em>tractatos his id. </blockquote><p><strong>Facer facilis definiebas ea pro, mei malis libris latine an. Senserit moderatius vituperata vis in.</strong></p>'); // eslint-disable-line max-len
   });
   it('should render blocks with single char correctly', () => {
-    const rendered = redraft(raw2, renderers);
+    const rendered = redraft(raws.raw2, renderers);
     const joined = joinRecursively(rendered);
     joined.should.equal('<p>!</p>');
   });
   it('should render blocks with depth correctly 1/2', () => {
-    const rendered = redraft(rawWithDepth, renderers);
+    const rendered = redraft(raws.rawWithDepth, renderers);
     const joined = joinRecursively(rendered);
     joined.should.equal("<ul><li>Hey<ul><li>Ho<ul><li>Let's</li></ul><ol><li>Go</li></ol></li></ul></li></ul>"); // eslint-disable-line max-len
   });
   it('should render blocks with depth correctly 2/2', () => {
-    const rendered = redraft(rawWithDepth2, renderers);
+    const rendered = redraft(raws.rawWithDepth2, renderers);
     const joined = joinRecursively(rendered);
     joined.should.equal("<ul><li>Hey<ul><li>Ho<ul><li>Let's</li></ul></li></ul></li></ul><ol><li>Go</li></ol>"); // eslint-disable-line max-len
   });
   it('should render blocks containing empty lines', () => {
-    const rendered = redraft(rawWithEmptyLine, renderers);
+    const rendered = redraft(raws.rawWithEmptyLine, renderers);
     const joined = joinRecursively(rendered);
     joined.should.equal('<p>!!</p>');
   });
   it('should render blocks when first block is empty', () => {
-    const rendered = redraft(rawEmptyFirstLine, renderers);
+    const rendered = redraft(raws.rawEmptyFirstLine, renderers);
     const joined = joinRecursively(rendered);
     joined.should.equal('<p>!</p>');
   });
   it('should render blocks with depth when depth jumps from 0 to 2', () => {
-    const rendered = redraft(rawWithDepth3, renderers);
+    const rendered = redraft(raws.rawWithDepth3, renderers);
     const joined = joinRecursively(rendered);
     joined.should.equal("<ul><li>Hey</li><li>Ho<ul><li>Let's</li></ul></li></ul><ol><li>Go</li></ol>"); // eslint-disable-line max-len
   });
   it('should style last node properly when its after an entity', () => {
-    const rendered = redraft(rawStyleWithEntities, renderers);
+    const rendered = redraft(raws.rawStyleWithEntities, renderers);
     const joined = joinRecursively(rendered);
     joined.should.equal('<p><strong>This </strong><div style="color: #ee6a56" ><strong>is a </strong></div><div style="color: #ee6a56" ><strong>Greeting</strong></div><div style="color: #ee6a56" ><strong> redraft</strong></div><strong>bug.</strong></p>'); // eslint-disable-line max-len
   });
   it('should render blocks with the block keys', () => {
-    const rendered = redraft(raw3, renderersWithKeys);
+    const rendered = redraft(raws.raw3, renderersWithKeys);
     const joined = joinRecursively(rendered);
     joined.should.equal('<p key="e047l">Paragraph one</p><blockquote key="520kr,c3taj">A quoteSpanning multiple lines</blockquote><p key="6aaeh">A second paragraph.</p>'); // eslint-disable-line max-len
   });
   it('should render atomic blocks with block metadata', () => {
-    const rendered = redraft(rawWithMetadata, renderersWithData);
+    const rendered = redraft(raws.rawWithMetadata, renderersWithData);
     const joined = joinRecursively(rendered);
     joined.should.equal('<div key="1" style="width: 300px;" >A</div><img key="2" src="img.png" alt="C" />'); // eslint-disable-line max-len
-  });
-  it('should render atomic blocks with cleanup enabled', () => {
-    const rendered = redraft(rawWithEmptyBlocks, renderersWithData);
-    const joined = joinRecursively(rendered);
-    joined.should.equal('<div key="1" style="width: 300px;" >A</div><img key="2" src="img.png" alt="C" /><p> </p>'); // eslint-disable-line max-len
-  });
-  it('should cleanup blocks with only whitlespace with trim enabled', () => {
-    const rendered = redraft(rawWithEmptyBlocks, renderersWithData, {
-      cleanup: { types: ['unstyled'], after: ['atomic'], trim: true },
-    });
-    const joined = joinRecursively(rendered);
-    joined.should.equal('<div key="1" style="width: 300px;" >A</div><img key="2" src="img.png" alt="C" />'); // eslint-disable-line max-len
-  });
-  it('should render empty blocks with cleanup disabled', () => {
-    const rendered = redraft(rawWithEmptyBlocks, renderersWithData, {
-      cleanup: false,
-    });
-    const joined = joinRecursively(rendered);
-    joined.should.equal('<div key="1" style="width: 300px;" >A</div><p></p><img key="2" src="img.png" alt="C" /><p> </p>'); // eslint-disable-line max-len
   });
   it('should render correctly without join', () => {
-    const rendered = redraft(raw, renderersNoJoin, { joinOutput: true });
+    const rendered = redraft(raws.raw, renderersNoJoin, { joinOutput: true });
     rendered.should.equal('<p><strong>Lorem </strong><a href="http://zombo.com/" ><strong><em>ipsum</em></strong></a><strong><em> dolor</em></strong><em> sit amet,</em> pro nisl sonet ad. </p><blockquote>Eos affert numquam id, in est meis nobis. Legimus singulis suscipiantur eum in, <em>ceteros invenire </em>tractatos his id. </blockquote><p><strong>Facer facilis definiebas ea pro, mei malis libris latine an. Senserit moderatius vituperata vis in.</strong></p>'); // eslint-disable-line max-len
   });
   it('should render null for empty raw blocks array', () => {
-    const rendered = redraft(emptyRaw, renderers);
+    const rendered = redraft(raws.emptyRaw, renderers);
     should.equal(rendered, null);
   });
   it('should return null for an invalid input 1/2', () => {
-    const rendered = redraft(invalidRaw, renderers);
+    const rendered = redraft(raws.invalidRaw, renderers);
     should.equal(rendered, null);
   });
   it('should return null for an invalid input 2/2', () => {


### PR DESCRIPTION
This enables cleanup settings for empty blocks, by default only for `unstyled` blocks after `atomic` ones, for cases described in #10. 

The `cleanup` option can be either false or an object.

```js
{
  cleanup: {
    after: ['atomic'], // array or 'all'
    types: ['unstyled'], // array or 'all'
    trim: false // if true will trim block text when checking if its an empty block
  }
}
```