### PR TITLE
fix unicode-aware string splitting 💩

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "react-dom": "^15.4.2",
     "rimraf": "^2.5.2",
     "tlds": "^1.183.0"
+  },
+  "dependencies": {
+    "runes": "^0.4.0"
   }
 }

--- a/src/RawParser.js
+++ b/src/RawParser.js
@@ -1,3 +1,4 @@
+import runes from 'runes';
 import ContentNode from './ContentNode';
 
 /**
@@ -128,7 +129,7 @@ export default class RawParser {
   parse({ text, inlineStyleRanges: ranges, entityRanges, decoratorRanges = [] }) {
     // Some unicode charactes actualy have length of more than 1
     // this creates an array of code points using es6 string iterator
-    this.textArray = Array.from(text);
+    this.textArray = runes(text);
     this.ranges = ranges;
     this.iterator = 0;
     // get all the relevant indexes for whole block


### PR DESCRIPTION
The Array.from(text) in RawParser has issues on Android with react-native in relation to emojis and the like. Whereas on iOS the following string gets split into a correct array: eg. the string 'Emoji inbound!!!💙'
-> results in a textArray from the "parse" function on iOS: ['E','m','o','j','i',' ','i','n','b','o','u','n','d','!','!','!','💙']
-> results in a textArray from the "parse" function on Android: ['E','m','o','j','i',' ','i','n','b','o','u','n','d','!','!','!','???','???']

This has probably something to do with the default charset of the packaged JavascriptCore in react-native on Android. There was a previous PR (PR16) using punycode to resolve this and subsequent discussion about performance. (I think the runes library uses this punycode library under the hood). 
Since fixing the problem on RN-Android is a bit "down the rabbithole" this fix has the added advantage of paying attention to surrogate pairs, a problem that the RN-Android charset fix wouldn't fix anyways.