### PR TITLE
Fix inline style key collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "react-dom": "^15.4.2",
     "rimraf": "^2.5.2",
     "tlds": "^1.183.0"
+  },
+  "dependencies": {
+    "lodash.assignwith": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,5 @@
     "rimraf": "^2.5.2",
     "tlds": "^1.183.0"
   },
-  "dependencies": {
-    "lodash.assignwith": "^4.2.0"
-  }
+  "dependencies": {}
 }

--- a/src/createStyleRenderer.js
+++ b/src/createStyleRenderer.js
@@ -1,19 +1,20 @@
-import _assignWith from 'lodash.assignwith';
-
 /**
  * Returns a single style object provided styleArray and stylesMap
  */
 const reduceStyles = (styleArray, stylesMap) => styleArray
   .map(style => stylesMap[style])
-  .reduce((prev, next) => _assignWith(prev, next, (objValue, srcValue) => {
-    // key conflict, assign the concatenated value to the key
-    if (objValue && srcValue) {
-      return objValue.concat(' ', srcValue);
+  .reduce((prev, next) => {
+    const mergedStyles = {};
+    if (next !== undefined) {
+      const key = 'text-decoration' in next ? 'text-decoration' : 'textDecoration';
+      if (next[key] !== prev[key]) {
+        // .trim() is necessary for IE9/10/11 and Edge
+        mergedStyles[key] = [prev[key], next[key]].join(' ').trim();
+      }
     }
-    // assign value
-    return undefined;
-  }), {}
-);
+    return Object.assign(prev, next, mergedStyles);
+  }, {});
+
 
 /**
  * Returns a styleRenderer from a customStyleMap and a wrapper callback (Component)

--- a/src/createStyleRenderer.js
+++ b/src/createStyleRenderer.js
@@ -1,9 +1,19 @@
+import _assignWith from 'lodash.assignwith';
+
 /**
  * Returns a single style object provided styleArray and stylesMap
  */
 const reduceStyles = (styleArray, stylesMap) => styleArray
   .map(style => stylesMap[style])
-  .reduce((prev, next) => Object.assign({}, prev, next), {});
+  .reduce((prev, next) => _assignWith(prev, next, (objValue, srcValue) => {
+    // key conflict, assign the concatenated value to the key
+    if (objValue && srcValue) {
+      return objValue.concat(' ', srcValue);
+    }
+    // assign value
+    return undefined;
+  }), {}
+);
 
 /**
  * Returns a styleRenderer from a customStyleMap and a wrapper callback (Component)

--- a/test/flat.js
+++ b/test/flat.js
@@ -17,6 +17,9 @@ const customStyleMap = {
   UNDERLINE: {
     'text-decoration': 'underline',
   },
+  STRIKETHROUGH: {
+    'text-decoration': 'line-through',
+  },
 };
 
 const customStyleMapReact = {
@@ -28,6 +31,9 @@ const customStyleMapReact = {
   },
   UNDERLINE: {
     textDecoration: 'underline',
+  },
+  STRIKETHROUGH: {
+    textDecoration: 'line-through',
   },
 };
 
@@ -86,8 +92,9 @@ const renderersReact = {
 // Helpers for te
 const bold = 'font-weight:bold;';
 const italic = 'font-style:italic;';
+const textDecoration = 'text-decoration:underline line-through;';
 
-const corretRender = `<p><span style="${bold}">Lorem </span><a href="http://zombo.com/"><span style="${bold}${italic}">ipsum</span></a><span style="${bold}${italic}"> dolor</span><span style="${italic}"> sit amet,</span> pro nisl sonet ad. </p><blockquote>Eos affert numquam id, in est meis nobis. Legimus singulis suscipiantur eum in, <span style="${italic}">ceteros invenire </span>tractatos his id. </blockquote><p><span style="${bold}">Facer facilis definiebas ea pro, mei malis libris latine an. Senserit moderatius vituperata vis in.</span></p>` // eslint-disable-line max-len
+const corretRender = `<p><span style="${bold}">Lorem </span><a href="http://zombo.com/"><span style="${bold}${italic}">ipsum</span></a><span style="${bold}${italic}${textDecoration}"> dolor</span><span style="${italic}"> sit amet,</span> pro nisl sonet ad. </p><blockquote>Eos affert numquam id, in est meis nobis. Legimus singulis suscipiantur eum in, <span style="${italic}">ceteros invenire </span>tractatos his id. </blockquote><p><span style="${bold}">Facer facilis definiebas ea pro, mei malis libris latine an. Senserit moderatius vituperata vis in.</span></p>` // eslint-disable-line max-len
 
 
 describe('redraft with flat styles', () => {

--- a/test/raws.js
+++ b/test/raws.js
@@ -24,6 +24,16 @@ export const raw = {
         length: 21,
         style: 'ITALIC',
       },
+      {
+        offset: 11,
+        length: 6,
+        style: 'UNDERLINE',
+      },
+      {
+        offset: 11,
+        length: 6,
+        style: 'STRIKETHROUGH',
+      },
     ],
     entityRanges: [
       {

--- a/test/render.js
+++ b/test/render.js
@@ -9,7 +9,9 @@ const should = chai.should();
 // render to HTML
 const inline = {
   BOLD: (children) => `<strong>${children.join('')}</strong>`,
-  ITALIC: (children) => `<em>${children.join('')}</em>`
+  ITALIC: (children) => `<em>${children.join('')}</em>`,
+  UNDERLINE: (children) => `<u>${children.join('')}</u>`,
+  STRIKETHROUGH: (children) => `<span style=text-decoration:line-through;>${children.join('')}</span>`,
 };
 
 const blocks = {
@@ -60,6 +62,8 @@ const blocksWithKeys = {
 const inlineNoJoin = {
   BOLD: (children) => `<strong>${children}</strong>`,
   ITALIC: (children) => `<em>${children}</em>`,
+  UNDERLINE: (children) => `<u>${children}</u>`,
+  STRIKETHROUGH: (children) => `<span style=text-decoration:line-through;>${children}</span>`,
 };
 
 const entitiesNoJoin = {
@@ -90,7 +94,7 @@ describe('redraft', () => {
   it('should render correctly', () => {
     const rendered = redraft(raws.raw, renderers);
     const joined = joinRecursively(rendered);
-    joined.should.equal('<p><strong>Lorem </strong><a href="http://zombo.com/" ><strong><em>ipsum</em></strong></a><strong><em> dolor</em></strong><em> sit amet,</em> pro nisl sonet ad. </p><blockquote>Eos affert numquam id, in est meis nobis. Legimus singulis suscipiantur eum in, <em>ceteros invenire </em>tractatos his id. </blockquote><p><strong>Facer facilis definiebas ea pro, mei malis libris latine an. Senserit moderatius vituperata vis in.</strong></p>'); // eslint-disable-line max-len
+    joined.should.equal('<p><strong>Lorem </strong><a href="http://zombo.com/" ><strong><em>ipsum</em></strong></a><strong><em><u><span style=text-decoration:line-through;> dolor</span></u></em></strong><em> sit amet,</em> pro nisl sonet ad. </p><blockquote>Eos affert numquam id, in est meis nobis. Legimus singulis suscipiantur eum in, <em>ceteros invenire </em>tractatos his id. </blockquote><p><strong>Facer facilis definiebas ea pro, mei malis libris latine an. Senserit moderatius vituperata vis in.</strong></p>'); // eslint-disable-line max-len
   });
   it('should render blocks with single char correctly', () => {
     const rendered = redraft(raws.raw2, renderers);
@@ -139,7 +143,7 @@ describe('redraft', () => {
   });
   it('should render correctly without join', () => {
     const rendered = redraft(raws.raw, renderersNoJoin, { joinOutput: true });
-    rendered.should.equal('<p><strong>Lorem </strong><a href="http://zombo.com/" ><strong><em>ipsum</em></strong></a><strong><em> dolor</em></strong><em> sit amet,</em> pro nisl sonet ad. </p><blockquote>Eos affert numquam id, in est meis nobis. Legimus singulis suscipiantur eum in, <em>ceteros invenire </em>tractatos his id. </blockquote><p><strong>Facer facilis definiebas ea pro, mei malis libris latine an. Senserit moderatius vituperata vis in.</strong></p>'); // eslint-disable-line max-len
+    rendered.should.equal('<p><strong>Lorem </strong><a href="http://zombo.com/" ><strong><em>ipsum</em></strong></a><strong><em><u><span style=text-decoration:line-through;> dolor</span></u></em></strong><em> sit amet,</em> pro nisl sonet ad. </p><blockquote>Eos affert numquam id, in est meis nobis. Legimus singulis suscipiantur eum in, <em>ceteros invenire </em>tractatos his id. </blockquote><p><strong>Facer facilis definiebas ea pro, mei malis libris latine an. Senserit moderatius vituperata vis in.</strong></p>'); // eslint-disable-line max-len
   });
   it('should render null for empty raw blocks array', () => {
     const rendered = redraft(raws.emptyRaw, renderers);


### PR DESCRIPTION
Fix for #28 

Uses lodash.assignWith to merge overlapping inline style in order to detect collision in keys