### PR TITLE
Downgrade to punycode v1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "tlds": "^1.183.0"
   },
   "dependencies": {
-    "punycode": "^2.1.0"
+    "punycode": "^1.4.1"
   }
 }


### PR DESCRIPTION
Punycode dropped browser support in v2.0.0 (see https://github.com/bestiejs/punycode.js/releases/tag/v2.0.0), so using a version > 2.0.0 causes Node shims to be included in the JS bundles.

This fixes it by downgrading to v1.4.1, which still has browser support! :tada: